### PR TITLE
Update HolderAuthentProgram.java

### DIFF
--- a/payment-sdk-common/src/main/java/com/worldline/sips/model/HolderAuthentProgram.java
+++ b/payment-sdk-common/src/main/java/com/worldline/sips/model/HolderAuthentProgram.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 public enum HolderAuthentProgram {
     ONE_EUROCOM,
     THREE_DS,
+    THREE_DS_V2,
     ARP,
     BCMCMOBILE,
     MASTERPASS,


### PR DESCRIPTION
Hello we are facing this kind of issue

2020-04-23 05:32:49.602 ERROR [http-nio-8080-exec-508][MercanetServlet:214] java.lang.IllegalArgumentException: Cannot construct instance of `com.worldline.sips.model.HolderAuthentProgram`, problem: No enum constant com.worldline.sips.model.HolderAuthentProgram.THREE_DS_V2_ at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.worldline.sips.model.ResponseData["holderAuthentProgram"]) (through reference chain: com.worldline.sips.model.PaypageResponse["Data"]) [Sanitized]
java.lang.IllegalArgumentException: Cannot construct instance of `com.worldline.sips.model.HolderAuthentProgram`, problem: No enum constant com.worldline.sips.model.HolderAuthentProgram.THREE_DS_V2_ at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.worldline.sips.model.ResponseData["holderAuthentProgram"]) (through reference chain: com.worldline.sips.model.PaypageResponse["Data"]) [Sanitized]
at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:3750)
at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:3668) 

Adding this new enum constant should be enough.
Please can the SDK be updated?
Also come back to me if something else is needed.

Thank you.