### PR TITLE
add global ObjectMapper

### DIFF
--- a/payment-sdk-common/src/main/java/com/worldline/sips/helper/ResponseDataDeserializer.java
+++ b/payment-sdk-common/src/main/java/com/worldline/sips/helper/ResponseDataDeserializer.java
@@ -3,31 +3,16 @@ package com.worldline.sips.helper;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer;
 import com.worldline.sips.model.ResponseData;
+import com.worldline.sips.util.ObjectMapperHolder;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ResponseDataDeserializer extends JsonDeserializer<ResponseData> {
-
-
-    private final ObjectMapper objectMapper;
-
-    public ResponseDataDeserializer() {
-        this.objectMapper = new ObjectMapper();
-    }
 
     @Override
     public ResponseData deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
@@ -41,11 +26,7 @@ public class ResponseDataDeserializer extends JsonDeserializer<ResponseData> {
                 .collect(Collectors.toMap(pair -> pair[0], pair -> pair[1]));
 
 
-        return objectMapper
-                .registerModule(new JavaTimeModule()
-                        .addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
-                        .addDeserializer(LocalDate.class, new LocalDateDeserializer(DateTimeFormatter.BASIC_ISO_DATE))
-                        .addDeserializer(YearMonth.class, new YearMonthDeserializer(DateTimeFormatter.ofPattern("yyyyMM"))))
+        return ObjectMapperHolder.INSTANCE.get().copy()
                 .convertValue(mapped, ResponseData.class);
 
     }

--- a/payment-sdk-common/src/main/java/com/worldline/sips/helper/RuleResultListDeserializer.java
+++ b/payment-sdk-common/src/main/java/com/worldline/sips/helper/RuleResultListDeserializer.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.worldline.sips.model.RuleResult;
+import com.worldline.sips.util.ObjectMapperHolder;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -13,18 +13,12 @@ import java.util.List;
 
 public class RuleResultListDeserializer extends JsonDeserializer<List<RuleResult>> {
 
-    private final ObjectMapper objectMapper;
-
-    public RuleResultListDeserializer() {
-        objectMapper = new ObjectMapper();
-    }
-
     @Override
     public List<RuleResult> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         if (p.getText() == null) {
             return Collections.emptyList();
         }
-        return objectMapper.readValue(p.getText().trim(), new TypeReference<List<RuleResult>>() {
-        });
+        return ObjectMapperHolder.INSTANCE.get().readerFor(new TypeReference<List<RuleResult>>() {
+        }).readValue(p.getText().trim());
     }
 }

--- a/payment-sdk-common/src/main/java/com/worldline/sips/util/ObjectMapperHolder.java
+++ b/payment-sdk-common/src/main/java/com/worldline/sips/util/ObjectMapperHolder.java
@@ -1,0 +1,36 @@
+package com.worldline.sips.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+
+public enum ObjectMapperHolder {
+    INSTANCE;
+
+    private final ObjectMapper mapper;
+
+    ObjectMapperHolder() {
+        this.mapper = create();
+    }
+
+    private static ObjectMapper create() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule()
+                .addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+                .addDeserializer(LocalDate.class, new LocalDateDeserializer(DateTimeFormatter.BASIC_ISO_DATE))
+                .addDeserializer(YearMonth.class, new YearMonthDeserializer(DateTimeFormatter.ofPattern("yyyyMM"))));
+    }
+
+    public ObjectMapper get() {
+        return this.mapper;
+    }
+}
+


### PR DESCRIPTION
Hi @CrlH,

I'm working on `sips-sdk-java` integration in my company.

IMHO, it could be better to use only a single instance of the heavy `ObjectMapper` class and add some thread safety, which is recommended. 

I'm waiting for feedback

Thanks